### PR TITLE
[Merged by Bors] - Add deprecation notice to releases.yaml and switch configured releases file to point it the new location of the releases file

### DIFF
--- a/releases.yaml
+++ b/releases.yaml
@@ -1,5 +1,11 @@
 ---
 releases:
+  This version of stackablectl has been deprecated, please update:
+    releaseDate: 2022-06-02
+    description:
+    products:
+      commons:
+        operatorVersion: 0.1.0
   22.05-sbernauer:
     releaseDate: 2022-05-06
     description: Non-offical release from sbernauer to demonstrate stackablectl. It includes the latest stable versions.

--- a/src/release.rs
+++ b/src/release.rs
@@ -13,8 +13,7 @@ use std::sync::Mutex;
 
 lazy_static! {
     pub static ref RELEASE_FILES: Mutex<Vec<String>> = Mutex::new(vec![
-        "https://raw.githubusercontent.com/stackabletech/release/main/releases.yaml"
-            .to_string()
+        "https://raw.githubusercontent.com/stackabletech/release/main/releases.yaml".to_string()
     ]);
 }
 

--- a/src/release.rs
+++ b/src/release.rs
@@ -13,7 +13,7 @@ use std::sync::Mutex;
 
 lazy_static! {
     pub static ref RELEASE_FILES: Mutex<Vec<String>> = Mutex::new(vec![
-        "https://raw.githubusercontent.com/stackabletech/stackablectl/main/releases.yaml"
+        "https://raw.githubusercontent.com/stackabletech/release/main/releases.yaml"
             .to_string()
     ]);
 }


### PR DESCRIPTION
We agreed in the architecture meeting that the releases definition file should rather reside in the `release` repository, than in this one.

I have abused the file in here to add a deprecation notice to the list of releases for people still using the old version of stackablectl and reconfigured the link to point it the new location here: https://github.com/stackabletech/release/blob/main/releases.yaml