### PR TITLE
[Merged by Bors] - Allow Unicode-DFS-2016 license

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,7 @@ allow = [
     "LicenseRef-ring",
     "LicenseRef-webpki",
     "MIT",
+    "Unicode-DFS-2016",
     "Zlib"
 ]
 exceptions = [


### PR DESCRIPTION
## Description

[unicode-ident](https://crates.io/crates/unicode-ident) which is used by [serde](https://crates.io/crates/serde) added the Unicode-DFS-2016 license in version 1.0.2.

Copied from https://github.com/stackabletech/operator-templating/pull/153

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)