### PR TITLE
[Merged by Bors] - Support generation of shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support generation of shell completions ([#54](https://github.com/stackabletech/stackablectl/pull/54))
+
 ### Changed
 
 - Update Rust and Go libs ([#46](https://github.com/stackabletech/stackablectl/pull/46))
-- Support generation of shell completions ([#54](https://github.com/stackabletech/stackablectl/pull/54))
 
 ## [0.2.0] - 2022-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Update Rust and Go libs ([#46](https://github.com/stackabletech/stackablectl/pull/46))
+- Support generation of shell completions ([#54](https://github.com/stackabletech/stackablectl/pull/54))
 
 ## [0.2.0] - 2022-05-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ead064480dfc4880a10764488415a97fdd36a4cf1bb022d372f02e8faf8386e1"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +954,7 @@ version = "0.2.0"
 dependencies = [
  "cached",
  "clap",
+ "clap_complete",
  "env_logger",
  "gobuild",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/stackabletech/stackablectl"
 [dependencies]
 cached = "0.36"
 clap = { version = "3.2", features = ["derive", "cargo"] }
+clap_complete = "3.2"
 env_logger = "0.9"
 indexmap = { version = "1.9", features = ["serde"] }
 lazy_static = "1.4"

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -2,7 +2,7 @@ use crate::{operator::CliCommandOperator, release::CliCommandRelease, stack::Cli
 use clap::{ArgEnum, Command, Parser, ValueHint};
 use clap_complete::{generate, Generator, Shell};
 use log::LevelFilter;
-use std::io;
+use std::{io};
 
 #[derive(Parser)]
 #[clap(author, version, about)]
@@ -10,9 +10,9 @@ pub struct CliArgs {
     #[clap(subcommand)]
     pub cmd: CliCommand,
 
-    /// Log level. One of error, warn, info, debug or trace
-    #[clap(short, long, default_value = "info", value_hint = ValueHint::Other)]
-    pub log_level: LevelFilter,
+    /// Log level.
+    #[clap(short, long, arg_enum, default_value = "info")]
+    pub log_level: LogLevel,
 
     /// Namespace where to deploy the products and operators
     #[clap(short, long, default_value = "default", value_hint = ValueHint::Other)]
@@ -83,6 +83,27 @@ pub enum OutputType {
     Text,
     Json,
     Yaml,
+}
+
+#[derive(Clone, Parser, Debug, ArgEnum)]
+pub enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<&LogLevel> for LevelFilter {
+    fn from(val: &LogLevel) -> Self {
+        match val {
+            LogLevel::Error => LevelFilter::Error,
+            LogLevel::Warn => LevelFilter::Warn,
+            LogLevel::Info => LevelFilter::Info,
+            LogLevel::Debug => LevelFilter::Debug,
+            LogLevel::Trace => LevelFilter::Trace,
+        }
+    }
 }
 
 #[derive(Parser)]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,6 +1,8 @@
 use crate::{operator::CliCommandOperator, release::CliCommandRelease, stack::CliCommandStack};
-use clap::{ArgEnum, Parser};
+use clap::{ArgEnum, Command, Parser};
+use clap_complete::{generate, Generator, Shell};
 use log::LevelFilter;
+use std::io;
 
 #[derive(Parser)]
 #[clap(author, version, about)]
@@ -68,6 +70,9 @@ pub enum CliCommand {
     /// This subcommand interacts with stacks, which are ready-to-use combinations of products.
     #[clap(subcommand, alias("s"), alias("st"))]
     Stack(CliCommandStack),
+
+    /// Output shell completion code for the specified shell.
+    Completion(CliCommandCompletion),
 }
 
 #[derive(Clone, Parser, ArgEnum)]
@@ -75,4 +80,15 @@ pub enum OutputType {
     Text,
     Json,
     Yaml,
+}
+
+#[derive(Parser)]
+pub struct CliCommandCompletion {
+    // Shell to generate the completions for
+    #[clap(arg_enum, value_parser)]
+    pub shell: Shell,
+}
+
+pub fn print_completions<G: Generator>(gen: G, cmd: &mut Command) {
+    generate(gen, cmd, cmd.get_name().to_string(), &mut io::stdout());
 }

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,5 +1,5 @@
 use crate::{operator::CliCommandOperator, release::CliCommandRelease, stack::CliCommandStack};
-use clap::{ArgEnum, Command, Parser};
+use clap::{ArgEnum, Command, Parser, ValueHint};
 use clap_complete::{generate, Generator, Shell};
 use log::LevelFilter;
 use std::io;
@@ -10,19 +10,20 @@ pub struct CliArgs {
     #[clap(subcommand)]
     pub cmd: CliCommand,
 
-    /// Log level. One of Error, Warn, Info, Debug or Trace
-    #[clap(short, long, default_value = "Info")]
+    /// Log level. One of error, warn, info, debug or trace
+    #[clap(short, long, default_value = "info", value_hint = ValueHint::Other)]
     pub log_level: LevelFilter,
 
     /// Namespace where to deploy the products and operators
-    #[clap(short, long, default_value = "default")]
+    #[clap(short, long, default_value = "default", value_hint = ValueHint::Other)]
     pub namespace: String,
 
     /// If you don't have access to the Stackable Helm repos you can mirror the repo and provide the URL here
     /// (e.g. <https://my.repo/repository/stackable-stable/>).
     #[clap(
         long,
-        default_value = "https://repo.stackable.tech/repository/helm-stable"
+        default_value = "https://repo.stackable.tech/repository/helm-stable",
+        value_hint = ValueHint::Url,
     )]
     pub helm_repo_stackable_stable: String,
 
@@ -30,7 +31,8 @@ pub struct CliArgs {
     /// (e.g. <https://my.repo/repository/stackable-test/>).
     #[clap(
         long,
-        default_value = "https://repo.stackable.tech/repository/helm-test"
+        default_value = "https://repo.stackable.tech/repository/helm-test",
+        value_hint = ValueHint::Url,
     )]
     pub helm_repo_stackable_test: String,
 
@@ -38,7 +40,8 @@ pub struct CliArgs {
     /// (e.g. <https://my.repo/repository/stackable-dev/>).
     #[clap(
         long,
-        default_value = "https://repo.stackable.tech/repository/helm-dev"
+        default_value = "https://repo.stackable.tech/repository/helm-dev",
+        value_hint = ValueHint::Url,
     )]
     pub helm_repo_stackable_dev: String,
 
@@ -46,14 +49,14 @@ pub struct CliArgs {
     /// Have a look [here](https://raw.githubusercontent.com/stackabletech/stackablectl/main/releases.yaml) for the structure.
     /// Can either be an URL or a path to a file e.g. `https://my.server/my-releases.yaml` or '/etc/my-releases.yaml' or `C:\Users\Sebastian\my-releases.yaml`.
     /// Can be specified multiple times.
-    #[clap(long, multiple_occurrences(true))]
+    #[clap(long, multiple_occurrences(true), value_hint = ValueHint::FilePath)]
     pub additional_release_files: Vec<String>,
 
     /// If you don't have access to the Stackable GitHub repos or you want to maintain your own stacks you can specify additional YAML files containing stack information.
     /// Have a look [here](https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks.yaml) for the structure.
     /// Can either be an URL or a path to a file e.g. `https://my.server/my-stacks.yaml` or '/etc/my-stacks.yaml' or `C:\Users\Sebastian\my-stacks.yaml`.
     /// Can be specified multiple times.
-    #[clap(long, multiple_occurrences(true))]
+    #[clap(long, multiple_occurrences(true), value_hint = ValueHint::FilePath)]
     pub additional_stack_files: Vec<String>,
 }
 

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -2,7 +2,7 @@ use crate::{operator::CliCommandOperator, release::CliCommandRelease, stack::Cli
 use clap::{ArgEnum, Command, Parser, ValueHint};
 use clap_complete::{generate, Generator, Shell};
 use log::LevelFilter;
-use std::{io};
+use std::io;
 
 #[derive(Parser)]
 #[clap(author, version, about)]

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -85,7 +85,7 @@ pub enum OutputType {
     Yaml,
 }
 
-#[derive(Clone, Parser, Debug, ArgEnum)]
+#[derive(Clone, Copy, Parser, Debug, ArgEnum)]
 pub enum LogLevel {
     Error,
     Warn,
@@ -94,8 +94,8 @@ pub enum LogLevel {
     Trace,
 }
 
-impl From<&LogLevel> for LevelFilter {
-    fn from(val: &LogLevel) -> Self {
+impl From<LogLevel> for LevelFilter {
+    fn from(val: LogLevel) -> Self {
         match val {
             LogLevel::Error => LevelFilter::Error,
             LogLevel::Warn => LevelFilter::Warn,

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -18,6 +18,8 @@ pub struct CliArgs {
     #[clap(short, long, default_value = "default", value_hint = ValueHint::Other)]
     pub namespace: String,
 
+    /// Overwrite the URL of the stable helm repo
+    ///
     /// If you don't have access to the Stackable Helm repos you can mirror the repo and provide the URL here
     /// (e.g. <https://my.repo/repository/stackable-stable/>).
     #[clap(
@@ -27,6 +29,8 @@ pub struct CliArgs {
     )]
     pub helm_repo_stackable_stable: String,
 
+    /// Overwrite the URL of the test helm repo
+    ///
     /// If you don't have access to the Stackable Helm repos you can mirror the repo and provide the URL here
     /// (e.g. <https://my.repo/repository/stackable-test/>).
     #[clap(
@@ -36,6 +40,8 @@ pub struct CliArgs {
     )]
     pub helm_repo_stackable_test: String,
 
+    /// Overwrite the URL of the dev helm repo
+    ///
     /// If you don't have access to the Stackable Helm repos you can mirror the repo and provide the URL here
     /// (e.g. <https://my.repo/repository/stackable-dev/>).
     #[clap(
@@ -45,6 +51,8 @@ pub struct CliArgs {
     )]
     pub helm_repo_stackable_dev: String,
 
+    /// Adds a YAML file containing custom releases
+    ///
     /// If you don't have access to the Stackable GitHub repos or you want to maintain your own releases you can specify additional YAML files containing release information.
     /// Have a look [here](https://raw.githubusercontent.com/stackabletech/stackablectl/main/releases.yaml) for the structure.
     /// Can either be an URL or a path to a file e.g. `https://my.server/my-releases.yaml` or '/etc/my-releases.yaml' or `C:\Users\Sebastian\my-releases.yaml`.
@@ -52,6 +60,8 @@ pub struct CliArgs {
     #[clap(long, multiple_occurrences(true), value_hint = ValueHint::FilePath)]
     pub additional_release_files: Vec<String>,
 
+    /// Adds a YAML file containing custom stacks
+    ///
     /// If you don't have access to the Stackable GitHub repos or you want to maintain your own stacks you can specify additional YAML files containing stack information.
     /// Have a look [here](https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks.yaml) for the structure.
     /// Can either be an URL or a path to a file e.g. `https://my.server/my-stacks.yaml` or '/etc/my-stacks.yaml' or `C:\Users\Sebastian\my-stacks.yaml`.

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -47,7 +47,7 @@ pub fn handle_common_cli_args(args: &CliArgs) {
         args.helm_repo_stackable_dev.clone(),
     );
 
-    *(LOG_LEVEL.lock().unwrap()) = (&args.log_level).into();
+    *(LOG_LEVEL.lock().unwrap()) = args.log_level.into();
 
     let namespace = &args.namespace;
     if namespace != "default" {

--- a/src/helm.rs
+++ b/src/helm.rs
@@ -47,7 +47,7 @@ pub fn handle_common_cli_args(args: &CliArgs) {
         args.helm_repo_stackable_dev.clone(),
     );
 
-    *(LOG_LEVEL.lock().unwrap()) = args.log_level;
+    *(LOG_LEVEL.lock().unwrap()) = (&args.log_level).into();
 
     let namespace = &args.namespace;
     if namespace != "default" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use crate::arguments::CliCommand;
 use arguments::CliArgs;
-use clap::Parser;
+use clap::{IntoApp, Parser};
 
 mod arguments;
 mod helm;
@@ -47,5 +47,9 @@ fn main() {
         CliCommand::Operator(command) => command.handle(),
         CliCommand::Release(command) => command.handle(),
         CliCommand::Stack(command) => command.handle(),
+        CliCommand::Completion(command) => {
+            let mut cmd = CliArgs::command();
+            arguments::print_completions(command.shell, &mut cmd);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
     env_logger::builder()
         .format_timestamp(None)
         .format_target(false)
-        .filter_level(args.log_level)
+        .filter_level((&args.log_level).into())
         .init();
     helm::handle_common_cli_args(&args);
     release::handle_common_cli_args(&args);

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
     env_logger::builder()
         .format_timestamp(None)
         .format_target(false)
-        .filter_level((&args.log_level).into())
+        .filter_level(args.log_level.into())
         .init();
     helm::handle_common_cli_args(&args);
     release::handle_common_cli_args(&args);

--- a/src/operator.rs
+++ b/src/operator.rs
@@ -1,5 +1,5 @@
 use crate::{arguments::OutputType, helm, helm::HELM_REPOS, kind, AVAILABLE_OPERATORS};
-use clap::Parser;
+use clap::{Parser, ValueHint};
 use indexmap::IndexMap;
 use log::{info, warn};
 use serde::Serialize;
@@ -16,6 +16,7 @@ pub enum CliCommandOperator {
     /// Show details of a specific operator
     #[clap(alias("desc"))]
     Describe {
+        #[clap(value_hint = ValueHint::Other)]
         operator: String,
         #[clap(short, long, arg_enum, default_value = "text")]
         output: OutputType,
@@ -26,7 +27,7 @@ pub enum CliCommandOperator {
         /// Space separated list of operators to install.
         /// Must have the form `name[=version]` e.g. `superset`, `superset=0.3.0`, `superset=0.3.0-nightly` or `superset=0.3.0-pr123`.
         /// You can get the available versions with `stackablectl operator list` or `stackablectl operator describe superset`
-        #[clap(multiple_occurrences(true), required = true)]
+        #[clap(multiple_occurrences(true), required = true, value_hint = ValueHint::Other)]
         operators: Vec<Operator>,
 
         /// If specified a local kubernetes cluster consisting of 4 nodes for testing purposes will be created.
@@ -39,7 +40,8 @@ pub enum CliCommandOperator {
         #[clap(
             long,
             default_value = "stackable-data-platform",
-            requires = "kind-cluster"
+            requires = "kind-cluster",
+            value_hint = ValueHint::Other,
         )]
         kind_cluster_name: String,
     },
@@ -47,7 +49,7 @@ pub enum CliCommandOperator {
     #[clap(alias("un"))]
     Uninstall {
         /// Space separated list of operators to uninstall.
-        #[clap(multiple_occurrences(true), required = true)]
+        #[clap(multiple_occurrences(true), required = true, value_hint = ValueHint::Other)]
         operators: Vec<String>,
     },
     /// List installed operators

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,6 +1,6 @@
 use crate::{arguments::OutputType, helpers, kind, operator, operator::Operator, CliArgs};
 use cached::proc_macro::cached;
-use clap::{ArgGroup, Parser};
+use clap::{ArgGroup, Parser, ValueHint};
 use indexmap::IndexMap;
 use lazy_static::lazy_static;
 use log::{error, info, warn};
@@ -24,6 +24,7 @@ pub enum CliCommandRelease {
     /// Show details of a specific release
     #[clap(alias("desc"))]
     Describe {
+        #[clap(value_hint = ValueHint::Other)]
         release: String,
         #[clap(short, long, arg_enum, default_value = "text")]
         output: OutputType,
@@ -37,17 +38,17 @@ pub enum CliCommandRelease {
     ))]
     Install {
         /// Name of the release to install
-        #[clap(required = true)]
+        #[clap(required = true, value_hint = ValueHint::Other)]
         release: String,
 
         /// Whitelist of product operators to install.
         /// Mutually exclusive with `--exclude-products`
-        #[clap(short, long)]
+        #[clap(short, long, value_hint = ValueHint::Other)]
         include_products: Vec<String>,
 
         /// Blacklist of product operators to install.
         /// Mutually exclusive with `--include-products`
-        #[clap(short, long)]
+        #[clap(short, long, value_hint = ValueHint::Other)]
         exclude_products: Vec<String>,
 
         /// If specified a local kubernetes cluster consisting of 4 nodes for testing purposes will be created.
@@ -60,7 +61,8 @@ pub enum CliCommandRelease {
         #[clap(
             long,
             default_value = "stackable-data-platform",
-            requires = "kind-cluster"
+            requires = "kind-cluster",
+            value_hint = ValueHint::Other,
         )]
         kind_cluster_name: String,
     },
@@ -68,7 +70,7 @@ pub enum CliCommandRelease {
     #[clap(alias("un"))]
     Uninstall {
         /// Name of the release to uninstall
-        #[clap(required = true)]
+        #[clap(required = true, value_hint = ValueHint::Other)]
         release: String,
     },
 }


### PR DESCRIPTION
## Description

For https://github.com/stackabletech/stackablectl/issues/37

This was surprisingly easy. Following the same semantics as `kubectl`.

Docs will be added via https://github.com/stackabletech/stackablectl/pull/36/commits/c97f6ac8eb1d0efda879b71858f877661d3c212f in https://github.com/stackabletech/stackablectl/pull/36.
We can copy parts of `kubectl` docs

You can try it out with `source <(stackablectl completion bash)` (for bash)

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)