### PR TITLE
[Merged by Bors] - Print Nifi adminuser credentials within services command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Added
 
+- Print Nifi adminuser credentials within services command ([#80](https://github.com/stackabletech/stackablectl/pull/80))
+
 ## [0.4.0] - 2022-08-19
+
+### Added
 
 - Support demos, which are an end-to-end demonstrations of the usage of the Stackable Data Platform ([#66](https://github.com/stackabletech/stackablectl/pull/66))
 

--- a/src/services.rs
+++ b/src/services.rs
@@ -352,13 +352,9 @@ pub async fn get_extra_infos(
             }
         }
         "nifi" => {
-            if let Some(admin_credentials_secret) = product_crd.data["spec"]
-                .get("config")
-                .and_then(|i| i.get("authentication"))
-                .and_then(|i| i.get("method"))
-                .and_then(|i| i.get("singleUser"))
-                .and_then(|i| i.get("adminCredentialsSecret"))
-                .and_then(|i| i.as_str())
+            if let Some(admin_credentials_secret) = product_crd.data["spec"]["config"]
+                ["authentication"]["method"]["singleUser"]["adminCredentialsSecret"]
+                .as_str()
             {
                 let credentials = get_credentials_from_secret(
                     admin_credentials_secret,


### PR DESCRIPTION
## Description

As requested by Felix

```
ka https://raw.githubusercontent.com/stackabletech/nifi-operator/main/examples/simple-nifi-cluster.yaml

cargo r svc ls
 PRODUCT    NAME         NAMESPACE  ENDPOINTS                       EXTRA INFOS                                      
                                                                                                                     
 nifi       simple-nifi  default    https https://172.18.0.4:31863  Admin user: admin, password: supersecretpassword 
                                                                                                                     
 zookeeper  simple-zk    default    zk    172.18.0.3:30469
```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)