### PR TITLE
[Merged by Bors] - Fix bug that prevents deserializing stacks and demos using serde_yaml 0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Sort operator versions descending ([#102](https://github.com/stackabletech/stackablectl/pull/102))
 
+### Fixed
+
+- Fix bug that prevents deserializing stacks and demos using `serde_yaml` 0.9 ([#103](https://github.com/stackabletech/stackablectl/pull/103))
+
 ### Removed
 - Remove Spark from supported operators ([#100](https://github.com/stackabletech/stackablectl/pull/100))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1324,9 +1324,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
+checksum = "89f31df3f50926cdf2855da5fd8812295c34752cb20438dae42a67f79e021ac3"
 dependencies = [
  "indexmap",
  "itoa 1.0.2",
@@ -1389,7 +1389,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml 0.9.10",
+ "serde_yaml 0.9.11",
  "tokio",
  "which",
 ]

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -88,6 +88,7 @@ pub fn handle_common_cli_args(args: &CliArgs) {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Demos {
+    #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     demos: IndexMap<String, Demo>,
 }
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -83,6 +83,7 @@ pub fn handle_common_cli_args(args: &CliArgs) {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct Stacks {
+    #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     stacks: IndexMap<String, Stack>,
 }
 


### PR DESCRIPTION
## Description

With `serde_yaml` 0.9 a bug was introduced that stopped us from parsing stacks and demos.
```
cargo r -- demo list 
    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
     Running `target/debug/stackablectl demo list`
[WARN ] Failed to parse demo list from https://raw.githubusercontent.com/stackabletech/stackablectl/main/demos/demos-v1.yaml: demos.trino-taxi-data.manifests[0]: invalid type: map, expected a YAML tag starting with '!' at line 14 column 9
```
This PR fixes this

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)