### PR TITLE
[Merged by Bors] - Enlarge Kafka and MinIO disk size in demo

### DIFF
--- a/stacks/kafka-druid-superset-s3/kafka.yaml
+++ b/stacks/kafka-druid-superset-s3/kafka.yaml
@@ -21,7 +21,7 @@ spec:
       resources:
         storage:
           logDirs:
-            capacity: 5Gi
+            capacity: 15Gi
         cpu:
           max: 500m
           min: 250m

--- a/stacks/stacks-v1.yaml
+++ b/stacks/stacks-v1.yaml
@@ -12,7 +12,7 @@ _templates:
         rootPassword: rootroot
         mode: standalone
         persistence:
-          size: 10Gi
+          size: 15Gi
         users:
           - accessKey: druid
             secretKey: druiddruid


### PR DESCRIPTION
## Description

After running the demo for some time kafka's disk run full. We actually had the same thing during the hackathon in Karlsruhe ^^

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)