### PR TITLE
[Merged by Bors] - hdfs-hbase stack: Increase pvc size

### DIFF
--- a/stacks/hdfs-hbase/hdfs.yaml
+++ b/stacks/hdfs-hbase/hdfs.yaml
@@ -25,7 +25,7 @@ spec:
       resources:
         storage:
           data:
-            capacity: 2Gi
+            capacity: 5Gi
     roleGroups:
       default:
         replicas: 2
@@ -34,7 +34,7 @@ spec:
       resources:
         storage:
           data:
-            capacity: 2Gi
+            capacity: 5Gi
     roleGroups:
       default:
         replicas: 1
@@ -43,7 +43,7 @@ spec:
       resources:
         storage:
           data:
-            capacity: 2Gi
+            capacity: 5Gi
     roleGroups:
       default:
         replicas: 1


### PR DESCRIPTION
## Description

When executing the hbase-hdfs demo on a non-kind cluster we have issues with storage. 
After setting org.apache.hadoop.hdfs.server.blockmanagement.BlockPlacementPolicy = DEBUG we can see the actual error saying 
```2022-10-04 14:26:23,414 DEBUG blockmanagement.BlockPlacementPolicy: The node 10.104.0.29:9866 does not have enough DISK space (required=134217728, scheduled=1476395008, remaining=1482951146).```

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)