### PR TITLE
[Merged by Bors] - Fix nifi.provenance.repository.max.storage.size in water-levels demo

### DIFF
--- a/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
+++ b/demos/nifi-kafka-druid-water-level-data/create-druid-ingestion-job.yaml
@@ -153,6 +153,7 @@ data:
             "station_uuid"
           ],
           "targetRowsPerSegment": 5000000
-        }
+        },
+        "maxNumSegmentsToMerge": 500,
       }
     }

--- a/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
@@ -26,13 +26,18 @@ spec:
           contentRepo:
             capacity: "10Gi"
           databaseRepo:
-            capacity: "5Gi"
+            capacity: "1Gi"
           flowfileRepo:
-            capacity: "5Gi"
+            capacity: "2Gi"
           provenanceRepo:
-            capacity: "5Gi"
+            capacity: "4Gi"
           stateRepo:
-            capacity: "5Gi"
+            capacity: "1Gi"
+    configOverrides:
+      nifi.properties:
+        nifi.ui.autorefresh.interval: "5s"
+        nifi.content.repository.archive.max.usage.percentage: "80%"
+        nifi.provenance.repository.max.storage.size: "3 GB"
     roleGroups:
       default:
         replicas: 1

--- a/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
+++ b/stacks/nifi-kafka-druid-superset-s3/nifi.yaml
@@ -35,7 +35,7 @@ spec:
             capacity: "1Gi"
     configOverrides:
       nifi.properties:
-        nifi.ui.autorefresh.interval: "5s"
+        # Can be removed once https://github.com/stackabletech/nifi-operator/issues/354 is fixed
         nifi.content.repository.archive.max.usage.percentage: "80%"
         nifi.provenance.repository.max.storage.size: "3 GB"
     roleGroups:


### PR DESCRIPTION
## Description

Related to https://github.com/stackabletech/nifi-operator/issues/354

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)