### PR TITLE
[Merged by Bors] - Bump kube to 0.76, k8s-openapi to 0.16 and openssl to 0.10.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Bump to clap 4.0 ([#150](https://github.com/stackabletech/stackablectl/pull/150))
 - Bump go modules such as helm to v3.10.1 and k8s client to v0.25.3 ([#149](https://github.com/stackabletech/stackablectl/pull/149))
-- Bump kube to 0.75, k8s-openapi to 0.16 and openssl to 0.10.42 ([#154](https://github.com/stackabletech/stackablectl/pull/154))
+- Bump kube to 0.76, k8s-openapi to 0.16 and openssl to 0.10.42 ([#154](https://github.com/stackabletech/stackablectl/pull/154))
 
 ## [0.5.0] - 2022-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Bump to clap 4.0 ([#150](https://github.com/stackabletech/stackablectl/pull/150))
 - Bump go modules such as helm to v3.10.1 and k8s client to v0.25.3 ([#149](https://github.com/stackabletech/stackablectl/pull/149))
+- Bump kube to 0.75, k8s-openapi to 0.16 and openssl to 0.10.42 ([#154](https://github.com/stackabletech/stackablectl/pull/154))
 
 ## [0.5.0] - 2022-09-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ae2c04fcee6b01b04e3aadd56bb418932c8e0a9d8a93f48bc68c6bdcdb559d"
+checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
 dependencies = [
  "base64",
  "bytes",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a527a8001a61d8d470dab27ac650889938760c243903e7cd90faaf7c60a34bdd"
+checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d48f42df4e8342e9f488c4b97e3759d0042c4e7ab1a853cc285adb44409480"
+checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
 dependencies = [
  "base64",
  "bytes",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.74.0"
+version = "0.75.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f56027f862fdcad265d2e9616af416a355e28a1c620bb709083494753e070d"
+checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
 dependencies = [
  "chrono",
  "form_urlencoded",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb19108692aeafebb108fd0a1c381c06ac4c03859652599420975165e939b8a"
+checksum = "fcf241a3a42bca4a2d1c21f2f34a659655032a7858270c7791ad4433aa8d79cb"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -823,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97e1a80ecd1b1438a2fc004549e155d47250b9e01fbfcf4cfbe9c8b56a085593"
+checksum = "7e442b4e6d55c4b3d0c0c70d79a8865bf17e2c33725f9404bfcb8a29ee002ffe"
 dependencies = [
  "base64",
  "bytes",
@@ -858,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.75.0"
+version = "0.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4d780f2bb048eeef64a4c6b2582d26a0fe19e30b4d3cc9e081616e1779c5d47"
+checksum = "eca2e1b1528287ba61602bbd17d0aa717fbb4d0fb257f4fa3a5fa884116ef778"
 dependencies = [
  "chrono",
  "form_urlencoded",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ clap_complete = "4.0"
 cli-table = "0.4"
 env_logger = "0.9"
 indexmap = { version = "1.9", features = ["serde"] }
-k8s-openapi = { version = "0.15", default-features = false, features = ["v1_24"] }
-kube = "0.74" # Using openssl (and not native-tls) as kube-rs team tries to move away from native-tls
+k8s-openapi = { version = "0.16", default-features = false, features = ["v1_24"] }
+kube = "0.75" # Using openssl (and not native-tls) as kube-rs team tries to move away from native-tls
 lazy_static = "1.4"
 log = "0.4"
-openssl = { version = "0.10.36", features = ["vendored"] } # Must match version from kube
+openssl = { version = "0.10.42", features = ["vendored"] } # Must match version from kube
 which = "4.2"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cli-table = "0.4"
 env_logger = "0.9"
 indexmap = { version = "1.9", features = ["serde"] }
 k8s-openapi = { version = "0.16", default-features = false, features = ["v1_24"] }
-kube = "0.75" # Using openssl (and not native-tls) as kube-rs team tries to move away from native-tls
+kube = "0.76" # Using openssl (and not native-tls) as kube-rs team tries to move away from native-tls
 lazy_static = "1.4"
 log = "0.4"
 openssl = { version = "0.10.42", features = ["vendored"] } # Must match version from kube


### PR DESCRIPTION
<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)