### PR TITLE
[Merged by Bors] - Create Hive/HDFS and Hive/S3 Trino stack for Hive migration testing

### DIFF
--- a/stacks/dual-hive-hdfs-s3/hdfs.yaml
+++ b/stacks/dual-hive-hdfs-s3/hdfs.yaml
@@ -23,7 +23,7 @@ kind: HdfsCluster
 metadata:
   name: hdfs
 spec:
-  version: 3.3.3-stackable0.1.0
+  version: 3.3.3-stackable0.2.0
   zookeeperConfigMapName: hdfs-znode
   dfsReplication: 1
   nameNodes:

--- a/stacks/dual-hive-hdfs-s3/hdfs.yaml
+++ b/stacks/dual-hive-hdfs-s3/hdfs.yaml
@@ -2,9 +2,9 @@
 apiVersion: zookeeper.stackable.tech/v1alpha1
 kind: ZookeeperCluster
 metadata:
-  name: simple-zk
+  name: hdfs-zk
 spec:
-  version: 3.8.0-stackable0.7.1
+  version: 3.8.0-stackable0.8.0
   servers:
     roleGroups:
       default:
@@ -13,18 +13,18 @@ spec:
 apiVersion: zookeeper.stackable.tech/v1alpha1
 kind: ZookeeperZnode
 metadata:
-  name: simple-hdfs-znode
+  name: hdfs-znode
 spec:
   clusterRef:
-    name: simple-zk
+    name: hdfs-zk
 ---
 apiVersion: hdfs.stackable.tech/v1alpha1
 kind: HdfsCluster
 metadata:
-  name: simple-hdfs
+  name: hdfs
 spec:
   version: 3.3.3-stackable0.1.0
-  zookeeperConfigMapName: simple-hdfs-znode
+  zookeeperConfigMapName: hdfs-znode
   dfsReplication: 1
   nameNodes:
     roleGroups:

--- a/stacks/dual-hive-hdfs-s3/hdfs.yaml
+++ b/stacks/dual-hive-hdfs-s3/hdfs.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperCluster
+metadata:
+  name: simple-zk
+spec:
+  version: 3.8.0-stackable0.7.1
+  servers:
+    roleGroups:
+      default:
+        replicas: 1
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperZnode
+metadata:
+  name: simple-hdfs-znode
+spec:
+  clusterRef:
+    name: simple-zk
+---
+apiVersion: hdfs.stackable.tech/v1alpha1
+kind: HdfsCluster
+metadata:
+  name: simple-hdfs
+spec:
+  version: 3.3.3-stackable0.1.0
+  zookeeperConfigMapName: simple-hdfs-znode
+  dfsReplication: 3
+  log4j: |-
+    # Define some default values that can be overridden by system properties
+    hadoop.root.logger=INFO,console
+    hadoop.log.dir=.
+    hadoop.log.file=hadoop.log
+    # Define the root logger to the system property "hadoop.root.logger".
+    log4j.rootLogger=${hadoop.root.logger}, EventCounter
+    # Logging Threshold
+    log4j.threshold=ALL
+    log4j.appender.console=org.apache.log4j.ConsoleAppender
+    log4j.appender.console.target=System.err
+    log4j.appender.console.layout=org.apache.log4j.PatternLayout
+    log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+    log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
+  nameNodes:
+    roleGroups:
+      default:
+        replicas: 2
+  dataNodes:
+    roleGroups:
+      default:
+        replicas: 1
+  journalNodes:
+    roleGroups:
+      default:
+        replicas: 1

--- a/stacks/dual-hive-hdfs-s3/hdfs.yaml
+++ b/stacks/dual-hive-hdfs-s3/hdfs.yaml
@@ -25,21 +25,7 @@ metadata:
 spec:
   version: 3.3.3-stackable0.1.0
   zookeeperConfigMapName: simple-hdfs-znode
-  dfsReplication: 3
-  log4j: |-
-    # Define some default values that can be overridden by system properties
-    hadoop.root.logger=INFO,console
-    hadoop.log.dir=.
-    hadoop.log.file=hadoop.log
-    # Define the root logger to the system property "hadoop.root.logger".
-    log4j.rootLogger=${hadoop.root.logger}, EventCounter
-    # Logging Threshold
-    log4j.threshold=ALL
-    log4j.appender.console=org.apache.log4j.ConsoleAppender
-    log4j.appender.console.target=System.err
-    log4j.appender.console.layout=org.apache.log4j.PatternLayout
-    log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
-    log4j.appender.EventCounter=org.apache.hadoop.log.metrics.EventCounter
+  dfsReplication: 1
   nameNodes:
     roleGroups:
       default:

--- a/stacks/dual-hive-hdfs-s3/hive.yaml
+++ b/stacks/dual-hive-hdfs-s3/hive.yaml
@@ -2,7 +2,7 @@
 apiVersion: secrets.stackable.tech/v1alpha1
 kind: SecretClass
 metadata:
-  name: simple-hive-s3-secret-class
+  name: hive-s3-secret-class
 spec:
   backend:
     k8sSearch:
@@ -18,14 +18,14 @@ spec:
   port: 9000
   accessStyle: Path
   credentials:
-    secretClass: simple-hive-s3-secret-class
+    secretClass: hive-s3-secret-class
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: simple-hive-s3-secret
+  name: hive-s3-secret
   labels:
-    secrets.stackable.tech/class: simple-hive-s3-secret-class
+    secrets.stackable.tech/class: hive-s3-secret-class
 stringData:
   accessKey: minio-access-key
   secretKey: minio-secret-key
@@ -37,7 +37,7 @@ metadata:
 spec:
   version: 2.3.9-stackable0.6.0
   hdfs:
-    configMap: simple-hdfs
+    configMap: hdfs
   metastore:
     roleGroups:
       default:
@@ -72,9 +72,6 @@ spec:
   metastore:
     roleGroups:
       default:
-        selector:
-          matchLabels:
-            kubernetes.io/os: linux
         replicas: 1
         config:
           database:

--- a/stacks/dual-hive-hdfs-s3/hive.yaml
+++ b/stacks/dual-hive-hdfs-s3/hive.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: secrets.stackable.tech/v1alpha1
+kind: SecretClass
+metadata:
+  name: simple-hive-s3-secret-class
+spec:
+  backend:
+    k8sSearch:
+      searchNamespace:
+        pod: {}
+---
+apiVersion: s3.stackable.tech/v1alpha1
+kind: S3Connection
+metadata:
+  name: minio
+spec:
+  host: minio
+  port: 9000
+  accessStyle: Path
+  credentials:
+    secretClass: simple-hive-s3-secret-class
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: simple-hive-s3-secret
+  labels:
+    secrets.stackable.tech/class: simple-hive-s3-secret-class
+stringData:
+  accessKey: minio-access-key
+  secretKey: minio-secret-key
+---
+apiVersion: hive.stackable.tech/v1alpha1
+kind: HiveCluster
+metadata:
+  name: hive-hdfs
+spec:
+  version: 2.3.9-stackable0.6.0
+  hdfs:
+    configMap: simple-hdfs
+  metastore:
+    roleGroups:
+      default:
+        selector:
+          matchLabels:
+            kubernetes.io/os: linux
+        replicas: 1
+        config:
+          database:
+            connString: jdbc:postgresql://hivehdfs-postgresql.default.svc.cluster.local:5432/hivehdfs
+            user: hive
+            password: hive
+            dbType: postgres
+          resources:
+            storage:
+              data:
+                capacity: 5Gi
+            cpu:
+              min: 300m
+              max: "2"
+            memory:
+              limit: 5Gi
+---
+apiVersion: hive.stackable.tech/v1alpha1
+kind: HiveCluster
+metadata:
+  name: hive-s3
+spec:
+  version: 3.1.3-stackable0.2.0
+  s3:
+    reference: minio
+  metastore:
+    roleGroups:
+      default:
+        selector:
+          matchLabels:
+            kubernetes.io/os: linux
+        replicas: 1
+        config:
+          database:
+            connString: jdbc:postgresql://hives3-postgresql.default.svc.cluster.local:5432/hives3
+            user: hive
+            password: hive
+            dbType: postgres
+          resources:
+            storage:
+              data:
+                capacity: 5Gi
+            cpu:
+              min: 300m
+              max: "2"
+            memory:
+              limit: 5Gi

--- a/stacks/dual-hive-hdfs-s3/trino.yaml
+++ b/stacks/dual-hive-hdfs-s3/trino.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: s3.stackable.tech/v1alpha1
+kind: S3Connection
+metadata:
+  name: minio
+spec:
+  host: minio
+  port: 9000
+  accessStyle: Path
+  credentials:
+    secretClass: simple-hive-s3-secret-class
+---
+apiVersion: trino.stackable.tech/v1alpha1
+kind: TrinoCatalog
+metadata:
+  name: hivehdfs
+  labels:
+    trino: simple-trino
+spec:
+  connector:
+    hive:
+      metastore:
+        configMap: hive-hdfs
+      hdfs:
+        configMap: simple-hdfs
+---
+apiVersion: trino.stackable.tech/v1alpha1
+kind: TrinoCatalog
+metadata:
+  name: hives3
+  labels:
+    trino: simple-trino
+spec:
+  connector:
+    hive:
+      metastore:
+        configMap: hive-s3
+      s3:
+        reference: minio
+---
+apiVersion: trino.stackable.tech/v1alpha1
+kind: TrinoCatalog
+metadata:
+  name: tpcds
+  labels:
+    trino: simple-trino
+spec:
+  connector:
+    tpcds: {}
+---
+apiVersion: trino.stackable.tech/v1alpha1
+kind: TrinoCluster
+metadata:
+  name: simple-trino
+spec:
+  version: 396-stackable0.1.0
+  catalogLabelSelector:
+    matchLabels:
+      trino: simple-trino
+  coordinators:
+    roleGroups:
+      default:
+        replicas: 1
+  workers:
+    roleGroups:
+      default:
+        replicas: 1
+  opa:
+    configMapName: opa
+    package: trino
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: trino-users
+type: kubernetes.io/opaque
+stringData:
+  # admin:admin
+  admin: $2y$10$89xReovvDLacVzRGpjOyAOONnayOgDAyIS2nW9bs5DJT98q17Dy5i
+  # demo:demo
+  demo: $2y$10$mMRoIKfWtAuycEQnKiDCeOlCSYiWkvbs0WsMFLkaSnNO0ZnFKVRXm
+---
+apiVersion: opa.stackable.tech/v1alpha1
+kind: OpaCluster
+metadata:
+  name: opa
+spec:
+  version: 0.41.0-stackable0.1.0
+  servers:
+    roleGroups:
+      default:
+        selector:
+          matchLabels:
+            kubernetes.io/os: linux
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trino-opa-bundle
+  labels:
+    opa.stackable.tech/bundle: "trino"
+data:
+  trino.rego: |
+    package trino
+    default allow = false
+    allow {
+      input.context.identity.user == "admin"
+    }
+    allow {
+      input.context.identity.user == "demo"
+    }

--- a/stacks/dual-hive-hdfs-s3/trino.yaml
+++ b/stacks/dual-hive-hdfs-s3/trino.yaml
@@ -53,7 +53,7 @@ kind: TrinoCluster
 metadata:
   name: trino
 spec:
-  version: 396-stackable0.1.0
+  version: 396-stackable0.2.0
   catalogLabelSelector:
     matchLabels:
       trino: trino

--- a/stacks/dual-hive-hdfs-s3/trino.yaml
+++ b/stacks/dual-hive-hdfs-s3/trino.yaml
@@ -8,28 +8,28 @@ spec:
   port: 9000
   accessStyle: Path
   credentials:
-    secretClass: simple-hive-s3-secret-class
+    secretClass: hive-s3-secret-class
 ---
 apiVersion: trino.stackable.tech/v1alpha1
 kind: TrinoCatalog
 metadata:
   name: hivehdfs
   labels:
-    trino: simple-trino
+    trino: trino
 spec:
   connector:
     hive:
       metastore:
         configMap: hive-hdfs
       hdfs:
-        configMap: simple-hdfs
+        configMap: hdfs
 ---
 apiVersion: trino.stackable.tech/v1alpha1
 kind: TrinoCatalog
 metadata:
   name: hives3
   labels:
-    trino: simple-trino
+    trino: trino
 spec:
   connector:
     hive:
@@ -43,7 +43,7 @@ kind: TrinoCatalog
 metadata:
   name: tpcds
   labels:
-    trino: simple-trino
+    trino: trino
 spec:
   connector:
     tpcds: {}
@@ -51,12 +51,12 @@ spec:
 apiVersion: trino.stackable.tech/v1alpha1
 kind: TrinoCluster
 metadata:
-  name: simple-trino
+  name: trino
 spec:
   version: 396-stackable0.1.0
   catalogLabelSelector:
     matchLabels:
-      trino: simple-trino
+      trino: trino
   coordinators:
     roleGroups:
       default:

--- a/stacks/stacks-v1.yaml
+++ b/stacks/stacks-v1.yaml
@@ -165,6 +165,29 @@ _templates:
         replica:
           replicaCount: 1
 
+  - helmChart: &template-postgresql-hivehdfs
+      releaseName: hivehdfs
+      name: postgresql
+      repo:
+        name: bitnami
+        url: https://charts.bitnami.com/bitnami/
+      version: 10.16.2
+      options:
+        postgresqlUsername: hive
+        postgresqlPassword: hive
+        postgresqlDatabase: hivehdfs
+  - helmChart: &template-postgresql-hives3
+      releaseName: hives3
+      name: postgresql
+      repo:
+        name: bitnami
+        url: https://charts.bitnami.com/bitnami/
+      version: 10.16.2
+      options:
+        postgresqlUsername: hive
+        postgresqlPassword: hive
+        postgresqlDatabase: hives3
+
 stacks:
   airflow:
     description: Stack containing Airflow scheduling platform
@@ -273,3 +296,19 @@ stacks:
       - plainYaml: https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks/trino-superset-s3/hive-metastore.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks/trino-superset-s3/trino.yaml
       - plainYaml: https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks/trino-superset-s3/superset.yaml
+  dual-hive-hdfs-s3:
+    description: Dual stack Hive on HDFS and S3 for Hadoop/Hive to Trino migration
+    stackableRelease: 22.11
+    labels:
+      - trino
+      - hive
+      - hdfs
+      - s3
+    manifests:
+      - helmChart: *template-postgresql-hivehdfs
+      - helmChart: *template-postgresql-hives3
+      - helmChart: *template-minio-trino
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks/dual-hive-hdfs-s3/hdfs.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks/dual-hive-hdfs-s3/hive.yaml
+      - plainYaml: https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks/dual-hive-hdfs-s3/trino.yaml
+


### PR DESCRIPTION
## Description

Create a stack that deploys 2 Hive metastores with HDFS and S3 plus Trino for testing legacy Hive migration.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)