### PR TITLE
[Merged by Bors] - changes for logging demo to work with release 23.1

### DIFF
--- a/demos/logging/zookeeper.yaml
+++ b/demos/logging/zookeeper.yaml
@@ -6,8 +6,10 @@ metadata:
 spec:
   image:
     productVersion: 3.8.0
-    stackableVersion: 0.9.0
-  vectorAggregatorConfigMapName: vector-aggregator-discovery
+    stackableVersion: "23.1"
+  clusterConfig:
+    logging:
+      vectorAggregatorConfigMapName: vector-aggregator-discovery
   servers:
     roleGroups:
       default:

--- a/stacks/stacks-v1.yaml
+++ b/stacks/stacks-v1.yaml
@@ -554,7 +554,7 @@ stacks:
       - plainYaml: https://raw.githubusercontent.com/stackabletech/stackablectl/main/stacks/dual-hive-hdfs-s3/trino.yaml
   logging:
     description: Stack containing OpenSearch, OpenSearch Dashboards, and Vector
-    stackableRelease: 23.01
+    stackableRelease: 23.1
     labels:
       - logging
       - opensearch


### PR DESCRIPTION
## Description

CRD fix and release version for the logging demo with release 23.1
N.B. to test locally `demos/demos-v1.yaml` should be changed so that the relevant plainYaml points at a local yaml:
`plainYaml: demos/logging/zookeeper.yaml`

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)