### PR TITLE
fix: Use stable helm repo for operators ending with "-dev"

### DIFF
--- a/src/operator.rs
+++ b/src/operator.rs
@@ -324,6 +324,7 @@ impl Operator {
         let helm_repo_name = match &self.version {
             None => "stackable-dev",
             Some(version) if version.ends_with("-nightly") => "stackable-dev",
+            Some(version) if version.ends_with("-dev") => "stackable-dev",
             Some(version) if version.contains("-pr") => "stackable-test",
             Some(_) => "stackable-stable",
         };


### PR DESCRIPTION
## Description

`cargo r -- operator install commons=0.0.0-dev`
`│ 2023-02-23T09:51:03.906493Z  INFO stackable_operator::utils: This is version 0.0.0-dev, built for x86_64-unknown-linux-gnu by rustc 1.65.0 (897e37553 2022-11-02) at Fri, 17 Feb 2023 17: │`

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)