### PR TITLE
[Merged by Bors] - Document why the auto-detection of the OpenSearch API version does not work

### DIFF
--- a/stacks/_templates/vector-aggregator.yaml
+++ b/stacks/_templates/vector-aggregator.yaml
@@ -20,6 +20,9 @@ options:
         endpoints:
           - https://opensearch-cluster-master.default.svc.cluster.local:9200
         mode: bulk
+        # The auto-detection of the API version does not work in Vector
+        # 0.31.0 for OpenSearch, so the version must be set explicitly
+        # (see https://github.com/vectordotdev/vector/issues/17690).
         api_version: v8
         tls:
           # Add the certificate of the Certificate Authority


### PR DESCRIPTION
## Description

Document why the auto-detection of the OpenSearch API version does not work

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)