### PR TITLE
Add support for merge queue

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,5 +10,3 @@
 - [ ] Documentation added (or not applicable)
 - [ ] Changelog updated (or not applicable)
 - [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
-
-Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
     tags:
       - "*"
   pull_request:
+  merge_group:
 
 env:
   CARGO_TERM_COLOR: always

--- a/bors.toml
+++ b/bors.toml
@@ -1,9 +1,0 @@
-status = [
-    '%' # All checks must pass before merging into main
-]
-delete_merged_branches = true
-use_squash_merge = true
-pr_status = [ 'license/cla' ]
-timeout_sec = 7200
-cut_body_after = "<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->"
-required_approvals = 1


### PR DESCRIPTION
## Description

CI now runs on Merge Queue branches

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)