### PR TITLE
Changed links to point to new demo/stack format

### DIFF
--- a/docs/modules/ROOT/pages/customization/add_demo.adoc
+++ b/docs/modules/ROOT/pages/customization/add_demo.adoc
@@ -8,7 +8,7 @@ Please keep in mind that a demo requires a stack to run on.
 Have a look at the chapter xref:customization/add_stack.adoc[] on how to create your own stack.
 
 == 1. Create a demos.yaml
-For a custom demo you need to create a `mycorp-demos.yaml` containing demos according to the format defined by https://github.com/stackabletech/stackablectl/blob/main/demos/demos-v1.yaml[the Stackable provided demos].
+For a custom demo you need to create a `mycorp-demos.yaml` containing demos according to the format defined by https://github.com/stackabletech/stackablectl/blob/main/demos/demos-v2.yaml[the Stackable provided demos].
 
 As of writing a `demos.yaml` file could look as follows:
 

--- a/docs/modules/ROOT/pages/customization/add_stack.adoc
+++ b/docs/modules/ROOT/pages/customization/add_stack.adoc
@@ -9,7 +9,7 @@ Please keep in mind that a stack requires a release to run on.
 In the most cases the stackable provided release should work absolutely fine, but you can also have a look at the chapter xref:customization/add_release.adoc[] on how to create your own release.
 
 == 1. Create a stacks.yaml
-For a custom stack you need to create a `mycorp-stacks.yaml` containing stacks according to the format defined by https://github.com/stackabletech/stackablectl/blob/main/stacks/stacks-v1.yaml[the Stackable provided stacks].
+For a custom stack you need to create a `mycorp-stacks.yaml` containing stacks according to the format defined by https://github.com/stackabletech/stackablectl/blob/main/stacks/stacks-v2.yaml[the Stackable provided stacks].
 
 As of writing a `stacks.yaml` file could look as follows:
 


### PR DESCRIPTION
## Description

Fixed the links to the demos/stacks format versions from v1 to v2.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
