### PR TITLE
Set HADOOP_USER_NAME in the hbase-hdfs-load-cycling-data demo

### DIFF
--- a/demos/hbase-hdfs-load-cycling-data/create-hfile-and-import-to-hbase.yaml
+++ b/demos/hbase-hdfs-load-cycling-data/create-hfile-and-import-to-hbase.yaml
@@ -11,6 +11,8 @@ spec:
         - name: create-hfile-and-import-to-hbase
           image: docker.stackable.tech/stackable/hbase:2.4.12-stackable23.4
           env:
+            - name: HADOOP_USER_NAME
+              value: stackable
             - name: HBASE_CONF_DIR
               value: "/stackable/conf/"
           volumeMounts:

--- a/demos/hbase-hdfs-load-cycling-data/distcp-cycling-data.yaml
+++ b/demos/hbase-hdfs-load-cycling-data/distcp-cycling-data.yaml
@@ -10,6 +10,8 @@ spec:
         - name: distcp-cycling-data
           image: docker.stackable.tech/stackable/hadoop:3.3.4-stackable23.4
           env:
+            - name: HADOOP_USER_NAME
+              value: stackable
             - name: HADOOP_CONF_DIR
               value: "/stackable/conf/hdfs"
             - name: HADOOP_CLASSPATH


### PR DESCRIPTION
## Description

Set the environment variable HADOOP_USER_NAME to "stackable" in the hbase-hdfs-load-cycling-data demo.

This is required on OpenShift because the chosen user ID has not the required access rights.

Without this change, the job distcp-cycling-data fails with:

```
mkdir: Permission denied: user=1000720000, access=WRITE, inode="/":stackable:supergroup:drwxr-xr-x
```

And the job create-hfile-and-import-to-hbase fails with:

```
Exception in thread "main" org.apache.hadoop.security.AccessControlException: Permission denied: user=1000720000, access=WRITE, inode="/":stackable:supergroup:drwxr-xr-x
```