### PR TITLE
When installing a release, install operators in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,6 +2626,7 @@ name = "stackable-cockpit"
 version = "0.0.0-dev"
 dependencies = [
  "bcrypt",
+ "futures",
  "helm-sys",
  "indexmap 2.1.0",
  "k8s-openapi",

--- a/rust/stackable-cockpit/Cargo.toml
+++ b/rust/stackable-cockpit/Cargo.toml
@@ -34,6 +34,7 @@ tracing.workspace = true
 url.workspace = true
 utoipa = { workspace = true, optional = true }
 which.workspace = true
+futures.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/rust/stackable-cockpit/src/platform/stack/spec.rs
+++ b/rust/stackable-cockpit/src/platform/stack/spec.rs
@@ -197,6 +197,7 @@ impl StackSpec {
         // Install the release
         release
             .install(&self.operators, &[], operator_namespace)
+            .await
             .context(InstallReleaseSnafu)
     }
 

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,11 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Operators are now installed in parallel when installing a release.
+
 ### Fixed
 
 - Fix `--cluster-name` not taking effect. The local test clusters always used the default cluster name ([#181]).
 
 [#181]: https://github.com/stackabletech/stackable-cockpit/pull/181
+[#202]: https://github.com/stackabletech/stackable-cockpit/pull/202
 
 ## [23.11.3] - 2024-01-03
 

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Operators are now installed in parallel when installing a release.
+- Operators are now installed in parallel when installing a release ([#202]).
 
 ### Fixed
 

--- a/rust/stackablectl/src/cmds/release.rs
+++ b/rust/stackablectl/src/cmds/release.rs
@@ -289,6 +289,7 @@ async fn install_cmd(
                     &args.excluded_products,
                     &args.operator_namespace,
                 )
+                .await
                 .context(ReleaseInstallSnafu)?;
 
             output


### PR DESCRIPTION
# Description

`stackablectl release install` is sloooow, partially because we wait for each operator to download/start before we start installing the next one.

We might as well try to install them in parallel.

Ideally each Helm operation would run on a background task (via tokio's `spawn_blocking`), but that's a much larger refactoring than this PR.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Helm chart can be installed and deployed operator works
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
