### PR TITLE
fix(helm-sys): Double the helm timeout after reported timeout errors

### DIFF
--- a/rust/helm-sys/go-helm-wrapper/main.go
+++ b/rust/helm-sys/go-helm-wrapper/main.go
@@ -39,7 +39,7 @@ func main() {
 func go_install_helm_release(releaseName *C.char, chartName *C.char, chartVersion *C.char, valuesYaml *C.char, namespace *C.char, suppressOutput bool) *C.char {
 	helmClient := getHelmClient(namespace, suppressOutput)
 
-	timeout, _ := time.ParseDuration("10m")
+	timeout, _ := time.ParseDuration("20m")
 	chartSpec := gohelm.ChartSpec{
 		ReleaseName: C.GoString(releaseName),
 		ChartName:   C.GoString(chartName),

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- helm-sys: Double the helm timeout to 20m ([#306])
+
+[#306]: https://github.com/stackabletech/stackable-cockpit/pull/306
+
 ## [24.3.6] - 2024-06-24
 
 ### Fixed


### PR DESCRIPTION
# Description

There have been multiple reports of errors when deploying to some clusters.

![image](https://github.com/stackabletech/stackable-cockpit/assets/10092581/c9b761b8-aaa6-47b9-8a34-e1c707fa5ec8)

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
