### PR TITLE
Restore broken Nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -24,20 +24,11 @@
       };
       utoipa-swagger-ui = attrs: rec {
         # utoipa-swagger-ui tries to redownload swagger-ui, which is blocked by Nix's sandboxing
-        # so we download it instead, and put it where it expects to be cached
-        preConfigure =
-          let
-            swaggerUi = pkgs.fetchurl {
-              url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.3.zip";
-              hash = "sha256-zrb8feuuDzt/g6y7Tucfh+Y2BWZov0soyNPR5LBqKx4=";
-            };
-          in ''
-            mkdir -p target/build/utoipa-swagger-ui.out
-            ln -s "${swaggerUi}" target/build/utoipa-swagger-ui.out/swagger-ui.zip
-          '';
-        # Build script only supports fetching from HTTP, not file URLs
-        # Last path element decides the cache key, which we rely on above
-        SWAGGER_UI_DOWNLOAD_URL = "file:///invalid-path/swagger-ui.zip";
+        # so we download it instead, and tell it to use that
+        SWAGGER_UI_DOWNLOAD_URL = "file://${pkgs.fetchurl {
+          url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.3.zip";
+          hash = "sha256-zrb8feuuDzt/g6y7Tucfh+Y2BWZov0soyNPR5LBqKx4=";
+        }}";
       };
     };
   }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "cf034861fdc4e091fc7c5f01d6c022dc46686cf1",
-        "sha256": "03gd74lrfwgkj21b1w8wabbhisvdk96r1a70jhmdvalz59cx7rmc",
+        "rev": "a6ca1e58132bab26fc08572f22a34bbb86f4d91d",
+        "sha256": "009m6xxz5ckq4is4rlwsmxyb09dap49yzxm34qc0pnvwvlklhx9g",
         "type": "tarball",
-        "url": "https://github.com/kolloch/crate2nix/archive/cf034861fdc4e091fc7c5f01d6c022dc46686cf1.tar.gz",
+        "url": "https://github.com/kolloch/crate2nix/archive/a6ca1e58132bab26fc08572f22a34bbb86f4d91d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "gomod2nix": {
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "nix-community",
         "repo": "gomod2nix",
-        "rev": "4702caff8e201f4c98fe3583637a930d253447c8",
-        "sha256": "1s0ihw1888rxpx8f7f5agr1vkjafszpz5jna7smi6n03irfcscyf",
+        "rev": "7b8ef0d5fdc09b3a7acb27f1e6c168888947f364",
+        "sha256": "0bcgv4zc6121y030mnqn3s0vw82m6n19rwxnm47k2ys2v5arr36c",
         "type": "tarball",
-        "url": "https://github.com/nix-community/gomod2nix/archive/4702caff8e201f4c98fe3583637a930d253447c8.tar.gz",
+        "url": "https://github.com/nix-community/gomod2nix/archive/7b8ef0d5fdc09b3a7acb27f1e6c168888947f364.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "1.5.0"
     },
@@ -42,10 +42,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e2dd4e18cc1c7314e24154331bae07df76eb582f",
-        "sha256": "19zbxf7rb787jvyrfhl4z9sn3aisd6xvx6ikybbi75ym9sy39jds",
+        "rev": "2122a9b35b35719ad9a395fe783eabb092df01b1",
+        "sha256": "0n2mfyakhpirbrv06qs5rd174f7nmnjmy7vkd1dim7sh340711fd",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/e2dd4e18cc1c7314e24154331bae07df76eb582f.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/2122a9b35b35719ad9a395fe783eabb092df01b1.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
# Description

24.7.0 breaks the Nix build for a few reasons:

1. utoipa-swagger-ui now supports file:// URLs (https://github.com/juhaku/utoipa/pull/923), so we need to provide a real file path
2. We now require Go >= 1.22.5, which is not available in the pinned Nixpkgs

This PR fixes 1 directly, and 2 by updating all pinned Nix libraries.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```
