### PR TITLE
chore: Release stackablectl 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,7 +3605,7 @@ dependencies = [
 
 [[package]]
 name = "stackablectl"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -11992,7 +11992,7 @@ rec {
       };
       "stackablectl" = rec {
         crateName = "stackablectl";
-        version = "1.2.0";
+        version = "1.2.1";
         edition = "2021";
         crateBin = [
           {

--- a/docs/modules/stackablectl/pages/installation.adoc
+++ b/docs/modules/stackablectl/pages/installation.adoc
@@ -1,7 +1,7 @@
 = Installation
 :page-aliases: stable@stackablectl::installation.adoc
 
-:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-1.2.0
+:latest-release: https://github.com/stackabletech/stackable-cockpit/releases/tag/stackablectl-1.2.1
 :fish-comp-loations: https://fishshell.com/docs/current/completions.html#where-to-put-completions
 :nushell-comp-locations: https://www.nushell.sh/book/custom_commands.html#persisting
 
@@ -23,14 +23,14 @@ You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.0/stackablectl-x86_64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.1/stackablectl-x86_64-unknown-linux-gnu
 ----
 
 **aarch64** (arm64):
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.0/stackablectl-aarch64-unknown-linux-gnu
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.1/stackablectl-aarch64-unknown-linux-gnu
 ----
 
 Install the binary into a directory in the `$PATH`, and make it executable:
@@ -60,14 +60,14 @@ You can also use the following command:
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.0/stackablectl-x86_64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.1/stackablectl-x86_64-apple-darwin
 ----
 
 **aarch64** (arm64):
 
 [source,console]
 ----
-$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.0/stackablectl-aarch64-apple-darwin
+$ curl -L -o stackablectl https://github.com/stackabletech/stackable-cockpit/releases/download/stackablectl-1.2.1/stackablectl-aarch64-apple-darwin
 ----
 
 Install the binary into a directory in the `$PATH`, and make it executable:

--- a/docs/modules/stackablectl/pages/release-notes.adoc
+++ b/docs/modules/stackablectl/pages/release-notes.adoc
@@ -5,6 +5,9 @@
 A full list of changes is available directly in https://github.com/stackabletech/stackable-cockpit/blob/main/rust/stackablectl/CHANGELOG.md[stackablectl's changelog].
 
 // WARNING: Please keep the empty newlines, otherwise headings are broken.
+
+include::partial$release-notes/release-1.2.1.adoc[]
+
 include::partial$release-notes/release-1.2.0.adoc[]
 
 include::partial$release-notes/release-1.1.0.adoc[]

--- a/docs/modules/stackablectl/partials/release-notes/release-1.2.1.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.2.1.adoc
@@ -1,0 +1,5 @@
+== 1.2.1
+
+* Don't crash during `release upgrade` for SDP 25.11.
+  Previously it errored with `HTTP status client error (404 Not Found) for url (https://raw.githubusercontent.com/stackabletech/secret-operator/main/deploy/helm/secret-operator/crds/crds.yaml)`, as the secret-operator now maintains the CRD itself ([#418]).
+  See https://github.com/stackabletech/stackable-cockpit/pull/418[stackable-cockpit#418].

--- a/extra/man/stackablectl.1
+++ b/extra/man/stackablectl.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH stackablectl 1  "stackablectl 1.2.0" 
+.TH stackablectl 1  "stackablectl 1.2.1" 
 .SH NAME
 stackablectl \- Command line tool to interact with the Stackable Data Platform
 .SH SYNOPSIS
@@ -120,6 +120,6 @@ EXPERIMENTAL: Launch a debug container for a Pod
 stackablectl\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH VERSION
-v1.2.0
+v1.2.1
 .SH AUTHORS
 Stackable GmbH <info@stackable.tech>

--- a/rust/stackablectl/Cargo.toml
+++ b/rust/stackablectl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stackablectl"
 description = "Command line tool to interact with the Stackable Data Platform"
 # See <project-root>/Cargo.toml
-version = "1.2.0"
+version = "1.2.1"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
### Fixed

- Don't crash during `release upgrade` for SDP 25.11.
  Previously it errored with `HTTP status client error (404 Not Found) for url (https://raw.githubusercontent.com/stackabletech/secret-operator/main/deploy/helm/secret-operator/crds/crds.yaml)`, as the secret-operator now maintains the CRD itself ([#418]).

[#418]: https://github.com/stackabletech/stackable-cockpit/pull/418
