### PR TITLE
feat(stackablectl): check for namespace before attempting uninstall

### DIFF
--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -11,10 +11,12 @@ All notable changes to this project will be documented in this file.
 - Add confirmation prompt to `install` subcommand for namespace selection ([#429]).
 - Add `--assume-yes` option for running commands non-interactively ([#429]).
 - Support Helm charts sourced from OCI registries in demo/stack manifests ([#440]).
+- Abort early if `uninstall` is issued for `default` namespace ([#442]).
 
 [#429]: https://github.com/stackabletech/stackable-cockpit/pull/429
 [#438]: https://github.com/stackabletech/stackable-cockpit/pull/438
 [#440]: https://github.com/stackabletech/stackable-cockpit/pull/440
+[#442]: https://github.com/stackabletech/stackable-cockpit/pull/442
 
 ## [1.4.0] - 2026-03-18
 

--- a/rust/stackablectl/CHANGELOG.md
+++ b/rust/stackablectl/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - Add confirmation prompt to `install` subcommand for namespace selection ([#429]).
 - Add `--assume-yes` option for running commands non-interactively ([#429]).
 - Support Helm charts sourced from OCI registries in demo/stack manifests ([#440]).
+
+### Changed
+
 - Abort early if `uninstall` is issued for `default` namespace ([#442]).
 
 [#429]: https://github.com/stackabletech/stackable-cockpit/pull/429

--- a/rust/stackablectl/src/cmds/demo.rs
+++ b/rust/stackablectl/src/cmds/demo.rs
@@ -183,6 +183,11 @@ pub enum CmdError {
         demo_name: String,
     },
 
+    #[snafu(display(
+        "demo {demo_name:?} cannot be uninstalled from the {DEFAULT_NAMESPACE:?} namespace, because Kubernetes does not allow deleting it. Pass --namespace <NAMESPACE> if the demo was installed in a different namespace, or delete the demo's resources manually"
+    ))]
+    UninstallFromDefaultNamespace { demo_name: String },
+
     #[snafu(display("failed to build labels for demo resources"))]
     BuildLabels { source: LabelError },
 
@@ -524,6 +529,13 @@ async fn uninstall_cmd(
 ) -> Result<String, CmdError> {
     // Init result output and progress output
     let mut output = Cli::result();
+
+    ensure!(
+        args.namespaces.namespace != DEFAULT_NAMESPACE,
+        UninstallFromDefaultNamespaceSnafu {
+            demo_name: args.demo_name.clone(),
+        }
+    );
 
     let proceed_with_uninstall = args.prompt_args.assume_yes
         || {

--- a/rust/stackablectl/src/cmds/stack.rs
+++ b/rust/stackablectl/src/cmds/stack.rs
@@ -178,6 +178,11 @@ pub enum CmdError {
         stack_name: String,
     },
 
+    #[snafu(display(
+        "stack {stack_name:?} cannot be uninstalled from the {DEFAULT_NAMESPACE:?} namespace, because Kubernetes does not allow deleting it. Pass --namespace <NAMESPACE> if the stack was installed in a different namespace, or delete the stack's resources manually"
+    ))]
+    UninstallFromDefaultNamespace { stack_name: String },
+
     #[snafu(display("failed to build labels for stack resources"))]
     BuildLabels { source: LabelError },
 
@@ -495,6 +500,13 @@ async fn uninstall_cmd(
     transfer_client: &xfer::Client,
 ) -> Result<String, CmdError> {
     let mut output = Cli::result();
+
+    ensure!(
+        args.namespaces.namespace != DEFAULT_NAMESPACE,
+        UninstallFromDefaultNamespaceSnafu {
+            stack_name: args.stack_name.clone(),
+        }
+    );
 
     let proceed_with_uninstall = args.prompt_args.assume_yes
         || tracing_indicatif::suspend_tracing_indicatif(|| -> Result<bool, CmdError> {


### PR DESCRIPTION
# Description

Checks for `default` namespace before attempting to uninstall.

Output looks like this:

```
stackablectl -s stacks/stacks-v2.yaml -d demos/demos-v2.yaml demo uninstall trino-taxi-data
An unrecoverable error occurred: failed to execute demo (sub)command

Caused by these errors (recent errors listed first):
 1: demo "trino-taxi-data" cannot be uninstalled from the "default" namespace, because Kubernetes does not allow deleting it. Pass --namespace <NAMESPACE> if the demo was installed in a different namespace, or delete the demo's resources manually
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
