### PR TITLE
docs: Add missing 1.5.0 header to release notes

### DIFF
--- a/docs/modules/stackablectl/partials/release-notes/release-1.5.0.adoc
+++ b/docs/modules/stackablectl/partials/release-notes/release-1.5.0.adoc
@@ -1,3 +1,5 @@
+== 1.5.0
+
 * Add heuristic for setting listener presets when the environment is Minikube
   See https://github.com/stackabletech/stackablectl/pull/438[stackablectl#438].
 * Add `uninstall` subcommand for `demo`/`stack` commands


### PR DESCRIPTION
This was missed in #447.