### PR TITLE
fix(nix): Update crate hashes

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -6174,7 +6174,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "84df2f110d2557fbd56a2ae583f2beb034b55c43";
-          sha256 = "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj";
+          sha256 = "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc";
         };
         libName = "k8s_version";
         authors = [
@@ -11481,7 +11481,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "84df2f110d2557fbd56a2ae583f2beb034b55c43";
-          sha256 = "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj";
+          sha256 = "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc";
         };
         libName = "stackable_operator";
         authors = [
@@ -11674,7 +11674,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "84df2f110d2557fbd56a2ae583f2beb034b55c43";
-          sha256 = "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj";
+          sha256 = "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc";
         };
         procMacro = true;
         libName = "stackable_operator_derive";
@@ -11709,7 +11709,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "84df2f110d2557fbd56a2ae583f2beb034b55c43";
-          sha256 = "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj";
+          sha256 = "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc";
         };
         libName = "stackable_shared";
         authors = [
@@ -11790,7 +11790,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "84df2f110d2557fbd56a2ae583f2beb034b55c43";
-          sha256 = "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj";
+          sha256 = "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc";
         };
         libName = "stackable_telemetry";
         authors = [
@@ -11900,7 +11900,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "84df2f110d2557fbd56a2ae583f2beb034b55c43";
-          sha256 = "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj";
+          sha256 = "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc";
         };
         libName = "stackable_versioned";
         authors = [
@@ -11950,7 +11950,7 @@ rec {
         src = pkgs.fetchgit {
           url = "https://github.com/stackabletech/operator-rs.git";
           rev = "84df2f110d2557fbd56a2ae583f2beb034b55c43";
-          sha256 = "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj";
+          sha256 = "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc";
         };
         procMacro = true;
         libName = "stackable_versioned_macros";

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,9 +1,9 @@
 {
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#k8s-version@0.1.3": "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-operator-derive@0.3.1": "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-operator@0.117.0": "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-shared@0.1.2": "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-telemetry@0.6.5": "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-versioned-macros@0.11.1": "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj",
-  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-versioned@0.11.1": "1v6slybgc0xqsmh3bxyid6xjvmz8ps41nfmmc6csgyzqs2v0wzxj"
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#k8s-version@0.1.3": "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-operator-derive@0.3.1": "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-operator@0.117.0": "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-shared@0.1.2": "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-telemetry@0.6.5": "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-versioned-macros@0.11.1": "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc",
+  "git+https://github.com/stackabletech/operator-rs.git?tag=stackable-operator-0.117.0#stackable-versioned@0.11.1": "15yl94dzkg2b9dg839hc4xsgv5jzdr7wdz1vq47vjkwz4iwmkmzc"
 }


### PR DESCRIPTION
For whatever reason, crate2nix doesn't update crate-hashes.json unless it has been deleted first.